### PR TITLE
Add Google login and improve news transitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@radix-ui/react-toggle": "^1.1.9",
         "@radix-ui/react-toggle-group": "^1.1.10",
         "@radix-ui/react-tooltip": "^1.2.7",
+        "@react-oauth/google": "^0.12.2",
         "@tanstack/react-query": "^5.83.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -2304,6 +2305,16 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
+    },
+    "node_modules/@react-oauth/google": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.12.2.tgz",
+      "integrity": "sha512-d1GVm2uD4E44EJft2RbKtp8Z1fp/gK8Lb6KHgs3pHlM0PxCXGLaq8LLYQYENnN4xPWO1gkL4apBtlPKzpLvZwg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
     },
     "node_modules/@remix-run/router": {
       "version": "1.23.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@radix-ui/react-toggle": "^1.1.9",
     "@radix-ui/react-toggle-group": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.7",
+    "@react-oauth/google": "^0.12.2",
     "@tanstack/react-query": "^5.83.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -23,10 +23,11 @@ const Footer = () => {
     {
       title: "Seções",
       links: [
-        { name: "Notícias", href: "#" },
-        { name: "Cultura Pop", href: "#" },
-        { name: "Comunidade", href: "#" },
-        { name: "Curiosidades", href: "#" }
+        { name: "Marília", href: "#" },
+        { name: "Região", href: "#" },
+        { name: "Brasil", href: "#" },
+        { name: "Mundo", href: "#" },
+        { name: "Entretenimento", href: "#" }
       ]
     },
     {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,15 +1,21 @@
 import { Search, Menu, User, Bell } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { useGoogleLogin } from "@react-oauth/google";
 
 const Header = () => {
   const menuItems = [
-    "Notícias",
-    "Comunidade", 
-    "Cultura Pop",
-    "Curiosidades",
-    "Contato"
+    "Marília",
+    "Região",
+    "Brasil",
+    "Mundo",
+    "Entretenimento"
   ];
+
+  const login = useGoogleLogin({
+    onSuccess: (tokenResponse) => console.log(tokenResponse),
+    onError: () => console.log("Login Failed"),
+  });
 
   return (
     <header className="sticky top-0 z-50 bg-background/95 backdrop-blur-md shadow-header border-b border-border">
@@ -55,7 +61,12 @@ const Header = () => {
               <Bell className="h-4 w-4" />
             </Button>
             
-            <Button size="sm" variant="outline" className="hidden md:flex">
+            <Button
+              size="sm"
+              variant="outline"
+              className="hidden md:flex"
+              onClick={() => login()}
+            >
               <User className="h-4 w-4 mr-2" />
               Entrar
             </Button>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -7,7 +7,7 @@ const HeroSection = () => {
     {
       id: 1,
       image: heroImage,
-      category: "ENTRETENIMENTO",
+      category: "MARÍLIA",
       title: "Quem é o responsável pelos eventos mais aguardados de Marília?",
       subtitle: "Conheça os bastidores da produção cultural da cidade",
       isMain: true
@@ -15,14 +15,14 @@ const HeroSection = () => {
     {
       id: 2,
       image: heroImage,
-      category: "CULTURA POP",
+      category: "REGIÃO",
       title: "Festival de música movimenta o centro da cidade",
       subtitle: "Três dias de shows gratuitos agitam Marília"
     },
     {
       id: 3,
       image: heroImage,
-      category: "COMUNIDADE",
+      category: "BRASIL",
       title: "Projeto social transforma vidas na periferia",
       subtitle: "Iniciativa oferece cursos e oportunidades para jovens"
     }
@@ -34,7 +34,7 @@ const HeroSection = () => {
         {/* Navigation Pills */}
         <div className="flex justify-center mb-8">
           <div className="flex bg-secondary rounded-full p-1 space-x-1">
-            {["Tudo", "Entretenimento", "Cultura", "Comunidade", "Esportes"].map((item, index) => (
+            {["Marília", "Região", "Brasil", "Mundo", "Entretenimento"].map((item, index) => (
               <button
                 key={item}
                 className={`px-4 py-2 rounded-full text-sm font-medium transition-colors ${
@@ -54,10 +54,10 @@ const HeroSection = () => {
           <div className="relative bg-card rounded-2xl overflow-hidden shadow-card">
             {/* Main Story */}
             <div className="relative h-96 lg:h-[500px]">
-              <img 
-                src={stories[0].image} 
+              <img
+                src={stories[0].image}
                 alt={stories[0].title}
-                className="w-full h-full object-cover"
+                className="w-full h-full object-cover bg-white"
               />
               
               {/* Overlay Content */}

--- a/src/components/NewsCard.tsx
+++ b/src/components/NewsCard.tsx
@@ -28,8 +28,8 @@ const NewsCard = ({
   variant = 'large'
 }: NewsCardProps) => {
   return (
-    <article 
-      className={`bg-card rounded-2xl shadow-card hover:shadow-lg transition-all duration-300 hover:-translate-y-1 overflow-hidden group ${
+    <article
+      className={`bg-card rounded-2xl shadow-card hover:shadow-lg transition-all duration-300 hover:-translate-y-1 overflow-hidden group animate-slide-up ${
         variant === 'large' ? 'md:flex md:h-48' : 'flex flex-col h-full'
       }`}
     >
@@ -39,10 +39,10 @@ const NewsCard = ({
           ? 'h-48 md:h-full md:w-2/5 flex-shrink-0' 
           : 'h-40 w-full'
       }`}>
-        <img 
-          src={image} 
+        <img
+          src={image}
           alt={title}
-          className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+          className="w-full h-full object-cover bg-white group-hover:scale-105 transition-transform duration-500"
         />
         
         {/* Badges Overlay */}

--- a/src/index.css
+++ b/src/index.css
@@ -142,7 +142,7 @@ All colors MUST be HSL.
   .scrollbar-hide::-webkit-scrollbar {
     display: none;
   }
-  
+
   /* Line clamp utilities */
   .line-clamp-2 {
     display: -webkit-box;
@@ -156,5 +156,9 @@ All colors MUST be HSL.
     -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
     overflow: hidden;
+  }
+
+  img {
+    @apply bg-white;
   }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,10 @@
-import { createRoot } from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
+import { createRoot } from 'react-dom/client';
+import App from './App.tsx';
+import './index.css';
+import { GoogleOAuthProvider } from '@react-oauth/google';
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <GoogleOAuthProvider clientId={import.meta.env.VITE_GOOGLE_CLIENT_ID || ""}>
+    <App />
+  </GoogleOAuthProvider>
+);


### PR DESCRIPTION
## Summary
- add Google OAuth provider and login button
- replace navigation categories with Marília, Região, Brasil, Mundo e Entretenimento
- animate news cards and enforce white background behind images

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, require style import, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d1c190444832693d71da8b3a2fd5d