### PR TITLE
Implement story pages, Google login and light theme

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import StoryPage from "./pages/Story";
 
 const queryClient = new QueryClient();
 
@@ -15,9 +16,10 @@ const App = () => (
       <Sonner />
       <BrowserRouter>
         <Routes>
-          <Route path="/" element={<Index />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
+            <Route path="/" element={<Index />} />
+            <Route path="/stories/:id" element={<StoryPage />} />
+            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+            <Route path="*" element={<NotFound />} />
         </Routes>
       </BrowserRouter>
     </TooltipProvider>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@ import { Search, Menu, User, Bell } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useGoogleLogin } from "@react-oauth/google";
+import { useState } from "react";
 
 const Header = () => {
   const menuItems = [
@@ -12,8 +13,27 @@ const Header = () => {
     "Entretenimento"
   ];
 
+  interface UserInfo {
+    name: string;
+    picture: string;
+  }
+
+  const [user, setUser] = useState<UserInfo | null>(null);
+
   const login = useGoogleLogin({
-    onSuccess: (tokenResponse) => console.log(tokenResponse),
+    onSuccess: async (tokenResponse) => {
+      try {
+        const res = await fetch("https://www.googleapis.com/oauth2/v3/userinfo", {
+          headers: {
+            Authorization: `Bearer ${tokenResponse.access_token}`,
+          },
+        });
+        const profile = await res.json();
+        setUser(profile);
+      } catch (err) {
+        console.error(err);
+      }
+    },
     onError: () => console.log("Login Failed"),
   });
 
@@ -61,15 +81,23 @@ const Header = () => {
               <Bell className="h-4 w-4" />
             </Button>
             
-            <Button
-              size="sm"
-              variant="outline"
-              className="hidden md:flex"
-              onClick={() => login()}
-            >
-              <User className="h-4 w-4 mr-2" />
-              Entrar
-            </Button>
+              {user ? (
+                <img
+                  src={user.picture}
+                  alt={user.name}
+                  className="w-8 h-8 rounded-full hidden md:block"
+                />
+              ) : (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="hidden md:flex"
+                  onClick={() => login()}
+                >
+                  <User className="h-4 w-4 mr-2" />
+                  Entrar
+                </Button>
+              )}
 
             {/* Mobile Search */}
             <Button size="sm" variant="ghost" className="md:hidden">

--- a/src/components/StoriesSection.tsx
+++ b/src/components/StoriesSection.tsx
@@ -1,42 +1,8 @@
 import { Badge } from "@/components/ui/badge";
-import news1 from "@/assets/news-1.jpg";
-import news2 from "@/assets/news-2.jpg"; 
-import news3 from "@/assets/news-3.jpg";
+import { Link } from "react-router-dom";
+import { stories as quickStories } from "@/lib/stories";
 
 const QuickStoriesSection = () => {
-  const quickStories = [
-    {
-      id: 1,
-      image: news1,
-      category: "CINEMA",
-      title: "Estreia bombástica no novo complexo"
-    },
-    {
-      id: 2,
-      image: news2,
-      category: "ESPORTES", 
-      title: "Vitória histórica do time local"
-    },
-    {
-      id: 3,
-      image: news3,
-      category: "CULTURA",
-      title: "Exposição de artistas marilienses"
-    },
-    {
-      id: 4,
-      image: news1,
-      category: "GASTRO",
-      title: "Festival gastronômico no centro"
-    },
-    {
-      id: 5,
-      image: news2,
-      category: "TECH",
-      title: "Cursos gratuitos de tecnologia"
-    }
-  ];
-
   return (
     <section className="bg-background py-8 border-b border-border">
       <div className="container mx-auto px-4">
@@ -49,36 +15,37 @@ const QuickStoriesSection = () => {
           </button>
         </div>
 
-        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-3">
-          {quickStories.map((story) => (
-            <article 
-              key={story.id}
-              className="group cursor-pointer"
-            >
-              <div className="relative aspect-[4/5] mb-2 overflow-hidden rounded-lg">
-                <img 
-                  src={story.image} 
-                  alt={story.title}
-                  className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
-                />
-                
-                <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent" />
-                
-                <div className="absolute top-2 left-2">
-                  <Badge className="bg-coral/90 text-white text-xs px-2 py-1 rounded">
-                    {story.category}
-                  </Badge>
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-3">
+            {quickStories.map((story) => (
+              <Link
+                key={story.id}
+                to={`/stories/${story.id}`}
+                className="group cursor-pointer"
+              >
+                <div className="relative aspect-[4/5] mb-2 overflow-hidden rounded-lg">
+                  <img
+                    src={story.image}
+                    alt={story.title}
+                    className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                  />
+
+                  <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent" />
+
+                  <div className="absolute top-2 left-2">
+                    <Badge className="bg-coral/90 text-white text-xs px-2 py-1 rounded">
+                      {story.category}
+                    </Badge>
+                  </div>
+
+                  <div className="absolute bottom-2 left-2 right-2">
+                    <h3 className="text-white text-sm font-medium line-clamp-2 group-hover:text-coral transition-colors">
+                      {story.title}
+                    </h3>
+                  </div>
                 </div>
-                
-                <div className="absolute bottom-2 left-2 right-2">
-                  <h3 className="text-white text-sm font-medium line-clamp-2 group-hover:text-coral transition-colors">
-                    {story.title}
-                  </h3>
-                </div>
-              </div>
-            </article>
-          ))}
-        </div>
+              </Link>
+            ))}
+          </div>
       </div>
     </section>
   );

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/index.css
+++ b/src/index.css
@@ -8,23 +8,24 @@ All colors MUST be HSL.
 
 @layer base {
   :root {
-    --background: 0 0% 4%;
-    --foreground: 0 0% 95%;
+    /* Light theme colors */
+    --background: 0 0% 100%;
+    --foreground: 0 0% 4%;
 
-    --card: 0 0% 8%;
-    --card-foreground: 0 0% 95%;
+    --card: 0 0% 100%;
+    --card-foreground: 0 0% 4%;
 
-    --popover: 0 0% 8%;
-    --popover-foreground: 0 0% 95%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 0 0% 4%;
 
     --primary: 207 69% 53%;
     --primary-foreground: 0 0% 100%;
 
-    --secondary: 0 0% 12%;
-    --secondary-foreground: 0 0% 85%;
+    --secondary: 0 0% 96%;
+    --secondary-foreground: 0 0% 20%;
 
-    --muted: 0 0% 12%;
-    --muted-foreground: 0 0% 65%;
+    --muted: 0 0% 96%;
+    --muted-foreground: 0 0% 40%;
 
     --accent: 16 100% 66%;
     --accent-foreground: 0 0% 100%;
@@ -32,8 +33,8 @@ All colors MUST be HSL.
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 100%;
 
-    --border: 0 0% 15%;
-    --input: 0 0% 12%;
+    --border: 0 0% 90%;
+    --input: 0 0% 90%;
     --ring: 207 69% 53%;
 
     /* Custom design tokens */

--- a/src/lib/stories.ts
+++ b/src/lib/stories.ts
@@ -1,0 +1,50 @@
+import news1 from "@/assets/news-1.jpg";
+import news2 from "@/assets/news-2.jpg";
+import news3 from "@/assets/news-3.jpg";
+
+export interface Story {
+  id: number;
+  image: string;
+  category: string;
+  title: string;
+  content: string;
+}
+
+export const stories: Story[] = [
+  {
+    id: 1,
+    image: news1,
+    category: "CINEMA",
+    title: "Estreia bombástica no novo complexo",
+    content: "Detalhes completos sobre a estreia bombástica no novo complexo de cinema em Marília."
+  },
+  {
+    id: 2,
+    image: news2,
+    category: "ESPORTES",
+    title: "Vitória histórica do time local",
+    content: "Resumo da vitória histórica que marcou os torcedores do time local."
+  },
+  {
+    id: 3,
+    image: news3,
+    category: "CULTURA",
+    title: "Exposição de artistas marilienses",
+    content: "Conheça a nova exposição que celebra os artistas marilienses e suas obras."
+  },
+  {
+    id: 4,
+    image: news1,
+    category: "GASTRO",
+    title: "Festival gastronômico no centro",
+    content: "Todos os sabores do festival gastronômico que tomou conta do centro da cidade."
+  },
+  {
+    id: 5,
+    image: news2,
+    category: "TECH",
+    title: "Cursos gratuitos de tecnologia",
+    content: "Informações sobre os cursos gratuitos de tecnologia disponíveis para a comunidade."
+  }
+];
+

--- a/src/pages/Story.tsx
+++ b/src/pages/Story.tsx
@@ -1,0 +1,40 @@
+import { useParams } from "react-router-dom";
+import Header from "@/components/Header";
+import Footer from "@/components/Footer";
+import { stories } from "@/lib/stories";
+
+const StoryPage = () => {
+  const { id } = useParams();
+  const story = stories.find((s) => s.id === Number(id));
+
+  if (!story) {
+    return (
+      <div className="min-h-screen flex flex-col">
+        <Header />
+        <main className="container mx-auto px-4 py-8 flex-1">
+          <p className="text-foreground">Matéria não encontrada.</p>
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="container mx-auto px-4 py-8 flex-1 animate-fade-in">
+        <h1 className="text-2xl font-bold mb-4 text-foreground">{story.title}</h1>
+        <img
+          src={story.image}
+          alt={story.title}
+          className="w-full max-h-96 object-cover rounded-lg mb-4"
+        />
+        <p className="text-base leading-relaxed text-foreground">{story.content}</p>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default StoryPage;
+

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -100,7 +101,7 @@ export default {
 				'accordion-down': 'accordion-down 0.2s ease-out',
 				'accordion-up': 'accordion-up 0.2s ease-out',
 				'fade-in': 'fade-in 0.5s ease-out',
-				'slide-up': 'slide-up 0.3s ease-out',
+                                'slide-up': 'slide-up 0.5s ease-in-out',
 				'pulse-soft': 'pulse-soft 2s ease-in-out infinite'
 			},
 			backgroundImage: {
@@ -128,5 +129,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- switch site to light theme with white background
- add Google OAuth login and show avatar
- link stories to dedicated pages with smoother entry animations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d23b58f7083269d9009878803acc5